### PR TITLE
JSON constant name clashing fix

### DIFF
--- a/lib/reqres_rspec/templates/spec.erb
+++ b/lib/reqres_rspec/templates/spec.erb
@@ -205,8 +205,8 @@
     <h5>Body</h5>
     <% if @record[:request][:body].present? %>
       <% lines = begin
-        JSON.pretty_generate(
-          JSON.parse(
+        ::JSON.pretty_generate(
+          ::JSON.parse(
             @record[:request][:body]
           )
         )
@@ -237,8 +237,8 @@
         <code>PDF document</code>
       <% else %>
         <% lines = begin
-                     JSON.pretty_generate(
-                       JSON.parse(
+                     ::JSON.pretty_generate(
+                       ::JSON.parse(
                          @record[:response][:body]
                        )
                      )


### PR DESCRIPTION
this prevents the following exception:
undefined method `pretty_generate' for ReqresRspec::Formatters::JSON:Class
 (NoMethodError)
