### PR TITLE
removed HTTP_ prefix from documented request headers

### DIFF
--- a/lib/reqres_rspec/collector.rb
+++ b/lib/reqres_rspec/collector.rb
@@ -155,7 +155,9 @@ module ReqresRspec
     def read_request_headers(request)
       headers = {}
       request.env.keys.each do |key|
-        headers.merge!(key => request.env[key]) if EXCLUDE_REQUEST_HEADER_PATTERNS.all? { |p| !key.starts_with? p }
+        if EXCLUDE_REQUEST_HEADER_PATTERNS.all? { |p| !key.starts_with? p }
+          headers.merge!(key.sub(/^HTTP_/, '') => request.env[key])
+        end
       end
       headers
     end


### PR DESCRIPTION
HTTP_ prefixed headers like HTTP_AUTHORIZATION are sending by clients just as AUTHORIZATION, so the documentation should respect it
