### PR TITLE
remove sorting by request path

### DIFF
--- a/lib/reqres_rspec.rb
+++ b/lib/reqres_rspec.rb
@@ -14,12 +14,14 @@ if defined?(RSpec) && ENV['REQRES_RSPEC'] == '1'
   collector = ReqresRspec::Collector.new
 
   RSpec.configure do |config|
-    config.after(:each) do
+    config.after(:each) do |example|
       if defined?(Rails)
         meta_data = self.class.example.metadata
-        if meta_data[:type] == :request && !meta_data[:skip_reqres] == true
+        skip_example = meta_data[:skip_reqres] || example.metadata[:skip_reqres]
+
+        if meta_data[:type] == :request && !skip_example
           begin
-            collector.collect(self, self.request, self.response)
+            collector.collect(self, example, self.request, self.response)
           rescue NameError
             raise $!
           end
@@ -37,7 +39,6 @@ if defined?(RSpec) && ENV['REQRES_RSPEC'] == '1'
 
     config.after(:suite) do
       if collector.records.size > 0
-        collector.sort
         ReqresRspec::Formatters.process(collector.records)
         ReqresRspec::Uploaders.upload if ENV['REQRES_UPLOAD'] == '1'
       end

--- a/lib/reqres_rspec/collector.rb
+++ b/lib/reqres_rspec/collector.rb
@@ -135,11 +135,6 @@ module ReqresRspec
       end.downcase.gsub(/[\W]+/, '_').gsub('__', '_').gsub(/^_|_$/, '')
     end
 
-    # sorts records alphabetically
-    def sort
-      self.records.sort!{ |x,y| x[:request_path] <=> y[:request_path] }
-    end
-
   private
 
     # read and cleanup response headers


### PR DESCRIPTION
It breaks initial order of specs (from "--order=defined" option)
