### PR TITLE
When reqres_title empty use description of example

### DIFF
--- a/lib/reqres_rspec/collector.rb
+++ b/lib/reqres_rspec/collector.rb
@@ -152,8 +152,15 @@ module ReqresRspec
     private
 
     def example_title(spec, example)
-      t = spec.class.metadata[:reqres_title] || example.metadata[:reqres_title] || spec.class.example.full_description
+      t = prepare_description(spec.class.metadata, :reqres_title) ||
+          prepare_description(example.metadata, :reqres_title) ||
+          spec.class.example.full_description
       t.strip
+    end
+
+    def prepare_description(payload, key)
+      payload[key] &&
+        ->(x) { (x.is_a?(TrueClass) || x == '') ? payload[:description] : x }.call(payload[key])
     end
 
     # read and cleanup response headers


### PR DESCRIPTION
Fix empty title when `reqres_title` value empty. Let setup `reqres_title`
as symbol on example or specification.