### PR TITLE
Don't take title from specification blocks

### DIFF
--- a/lib/reqres_rspec/collector.rb
+++ b/lib/reqres_rspec/collector.rb
@@ -152,8 +152,7 @@ module ReqresRspec
     private
 
     def example_title(spec, example)
-      t = prepare_description(spec.class.metadata, :reqres_title) ||
-          prepare_description(example.metadata, :reqres_title) ||
+      t = prepare_description(example.metadata, :reqres_title) ||
           spec.class.example.full_description
       t.strip
     end


### PR DESCRIPTION
Prevent using reqres_title on `description`, `context` or another
specification elements. Setup `reqres_title` only on example. Any
reqres_title defined out of example block (e.g. `it`) will be ignored.