### PR TITLE
Updating aws-core-sdk to 3

### DIFF
--- a/lib/reqres_rspec/version.rb
+++ b/lib/reqres_rspec/version.rb
@@ -1,3 +1,3 @@
 module ReqresRspec
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end

--- a/reqres_rspec.gemspec
+++ b/reqres_rspec.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'coderay'
   spec.add_dependency 'mime-types'
-  spec.add_dependency 'aws-sdk-core', '~> 2.0'
+  spec.add_dependency 'aws-sdk-core', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Updating the `aws-core-sdk` requirement for modern rails apps.